### PR TITLE
added note about audio normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ If you don't pass in a correct email and password, the script will prompt you fo
 Or, you can run `dart pub get` from the script folder, and then `dart ./bin/index.dart -e EMAIL -p PASSWORD`.
 (You'll have to install the [dart sdk][dart sdk download page] to run dart commands.)
 
+### Audio Normalization (optional)
+I noticed, at least in the French course, that the audio in some lessons was much quieter than others, and it bothered me. I fixed it using [mp3gain](https://mp3gain.sourceforge.net/):
+
+```
+cp -a audio audio.mp3gain
+mp3gain -r -k -s r audio.mp3gain/*
+```
+
+Use the normalized `audio.mp3gain` folder in the next step rather than the `audio` folder if you do this.
+
 ### Using the decks
 See [the anki import docs][anki import]
 
@@ -49,7 +59,7 @@ See [the anki import docs][anki import]
 2. Copy over the audio from the audio folder (after you run the script) into anki's audio folder.
    - On Windows, this will be something like `USERNAME\AppData\Roaming\Anki2\User 1\collection.media`
    - on Apple: `USERNAME/ANKI/User1/collection.media`
-   - on Linux (flatpak): `cp audio/* "~/.var/app/net.ankiweb.Anki/data/Anki2/User 1/collection.media/"`
+   - on Linux (flatpak): `cp audio/* ~/.var/app/net.ankiweb.Anki/data/Anki2/User\ 1/collection.media/`
 3. Open anki, and import the generated decks' text files from `decks/PRODUCTNAME.txt`
 
 ## Limitations


### PR DESCRIPTION
Maybe this belongs in a different file than README. I tried a few other things. The way documented in the PR did a decent job normalizing the audio, and is pretty fast. There are ways to normalize it even more; mp3gain uses an old, sub-optimal loudness-measurement algorithm. But the tool that did the best job during testing (https://github.com/slhck/ffmpeg-normalize) crashed when I tried running all 10k audio files thru it:

```
uvx ffmpeg-normalize audio/*.mp3 -ext mp3 -c:a mp3
```

- mp3gain uses old ReplayGain1 algorithm
- ffmpeg-normalize uses the newer EBU-R128 algorithm, and is way slower